### PR TITLE
Use new version of Gluon Wave and sync contacts at every startup

### DIFF
--- a/App/pom.xml
+++ b/App/pom.xml
@@ -160,7 +160,7 @@
         <dependency>
             <groupId>com.gluonhq</groupId>
             <artifactId>wave</artifactId>
-            <version>0.9.2</version>
+            <version>0.9.3</version>
         </dependency>
 
         <dependency>

--- a/App/src/main/java/com/gluonhq/chat/GluonChat.java
+++ b/App/src/main/java/com/gluonhq/chat/GluonChat.java
@@ -56,7 +56,12 @@ public class GluonChat extends Application {
 
     @Override
     public void start(Stage stage) {
-        appManager.start(stage);
+        try {
+            appManager.start(stage);
+        } catch (Throwable t) {
+            System.err.println("This should never happen, but we're still in development:");
+            t.printStackTrace();
+        }
     }
 
     private void postInit(Scene scene) {

--- a/App/src/main/java/com/gluonhq/chat/model/Channel.java
+++ b/App/src/main/java/com/gluonhq/chat/model/Channel.java
@@ -1,5 +1,6 @@
 package com.gluonhq.chat.model;
 
+import java.util.Objects;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 
@@ -17,19 +18,25 @@ public class Channel extends Searchable {
     private boolean unread;
     private BooleanProperty typing = new SimpleBooleanProperty(false);
 
-    public Channel(String name, ObservableList<User> members, ObservableList<ChatMessage> messages) {
-        this.id = UUID.randomUUID().toString();
+
+    public Channel(String id, String name, ObservableList<User> members, ObservableList<ChatMessage> messages) {
+        this.id = id;
         this.name = name;
         this.members = members;
         this.messages = messages;
     }
 
+    public Channel(String name, ObservableList<User> members, ObservableList<ChatMessage> messages) {
+        this(UUID.randomUUID().toString(), name, members, messages);
+    }
+
     /**
-     * Create a direct channel with a user
+     * Create a direct channel with a user. In this case, the unique ID of the channel is 
+     * c + the unique userid
      * @param user Direct channel with
      */
     public Channel(User user, ObservableList<ChatMessage> messages) {
-        this(user.displayName(), FXCollections.observableArrayList(user), messages);
+        this("c"+user.getId(), user.displayName(), FXCollections.observableArrayList(user), messages);
         this.isDirect = true;
     }
 
@@ -94,5 +101,34 @@ public class Channel extends Searchable {
     
     public String displayName() {
         return isDirect ? name : "# " + name;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 53 * hash + Objects.hashCode(this.id);
+        hash = 53 * hash + Objects.hashCode(this.name);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final Channel other = (Channel) obj;
+        if (!Objects.equals(this.id, other.id)) {
+            return false;
+        }
+        if (!Objects.equals(this.name, other.name)) {
+            return false;
+        }
+        return true;
     }
 }

--- a/App/src/main/java/com/gluonhq/chat/service/WaveService.java
+++ b/App/src/main/java/com/gluonhq/chat/service/WaveService.java
@@ -58,6 +58,7 @@ public class WaveService implements Service, ProvisioningClient, MessagingClient
             this.wave.setMessageListener(this);
             try {
                 this.wave.ensureConnected();
+                wave.syncContacts();
             } catch (IOException ex) {
                 ex.printStackTrace();
                 System.err.println("We're offline. Not much we can do now!");
@@ -296,7 +297,6 @@ public class WaveService implements Service, ProvisioningClient, MessagingClient
             wave.getWaveLogger().log(Level.DEBUG, "[WAVESERVICE] synccontacts");
             wave.syncContacts();
             Platform.runLater(() -> bootstrapClient.bootstrapSucceeded());
-
         } catch (Exception ex) {
             ex.printStackTrace();
         }

--- a/App/src/main/java/com/gluonhq/chat/service/WaveService.java
+++ b/App/src/main/java/com/gluonhq/chat/service/WaveService.java
@@ -132,7 +132,12 @@ public class WaveService implements Service, ProvisioningClient, MessagingClient
                 List<Channel> addedChannels = change.getAddedSubList().stream()
                         .map(user -> createChannelFromUser(user))
                         .collect(Collectors.toList());
-                answer.addAll(addedChannels);
+                Platform.runLater(() -> answer.addAll(addedChannels));
+                List<Channel> removedChannels = change.getRemoved().stream()
+                        .map(user -> findChannelByUser(user, answer))
+                        .filter(opt -> opt.isPresent())
+                        .map(opt -> opt.get()).collect(Collectors.toList());
+                Platform.runLater(() -> answer.removeAll(removedChannels));
             }
         });
         return answer;
@@ -341,11 +346,11 @@ public class WaveService implements Service, ProvisioningClient, MessagingClient
         return target;
     }
 
-    // this will never give a match since we use a random id when creating a channel.
-    // There is no 1-1 relation between User and Channel in case a channel has many users.
+    // A direct channel has an id "c" + userId. This is brittle though, and should be
+    // made more robust once we introduce group channels
     private Optional<Channel> findChannelByUser(User user, List<Channel> channels) {
-        String cuuid = user.getId();
-        Optional<Channel> target = channels.stream().filter(u -> u.getId().equals(cuuid)).findFirst();
+        String cuuid = "c" + user.getId();
+        Optional<Channel> target = channels.stream().filter(c -> c.getId().equals(cuuid)).findFirst();
         return target;
     }
 


### PR DESCRIPTION
Previously, contacts were only synced during provisioning. If that somehow failed, contacts were never retrieved and all messages were discarded since the destination/sender could not be found in contacts.
We now ask to synchronize the contacts every time the application starts.